### PR TITLE
Preserve name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ function old (Class) {
   assign(WrapperClass, Class)
   WrapperClass.prototype = assign({}, Class.prototype)
   WrapperClass.prototype[_super] = Class
+  Object.defineProperty(WrapperClass, 'name', { value: Class.name })
   return WrapperClass
 }
 


### PR DESCRIPTION
This PR preserves the name of the wrapped class.

Before this change:

```javascript
require('old')(class Foo {}).name
// => WrapperClass
```

After this change:
```javascript
require('old')(class Foo {}).name
// => Foo
```